### PR TITLE
HttpProxy - Proper formatting for specific content types

### DIFF
--- a/http/HttpProxy.js
+++ b/http/HttpProxy.js
@@ -411,7 +411,7 @@ export default class HttpProxy {
     };
 
     if (this._shouldRequestHaveBody(method, data)) {
-      requestInit.body = JSON.stringify(data);
+      requestInit.body = this._transformRequestBody(data, options.headers);
     }
 
     Object.assign(requestInit, options.fetchOptions || {});
@@ -453,9 +453,7 @@ export default class HttpProxy {
    */
   _composeRequestUrl(url, data) {
     const transformedUrl = this._transformer.transform(url);
-    const queryString = Object.keys(data || {})
-      .map(key => [key, data[key]].map(encodeURIComponent).join('='))
-      .join('&');
+    const queryString = this._convertObjectToQueryString(data || {});
     const delimeter = queryString
       ? transformedUrl.includes('?') ? '&' : '?'
       : '';
@@ -474,5 +472,61 @@ export default class HttpProxy {
    */
   _shouldRequestHaveBody(method, data) {
     return ['get', 'head'].indexOf(method.toLowerCase()) === -1 && data;
+  }
+
+  /**
+   * Formats request body according to request headers.
+   *
+   * @param {Object.<string, (boolean|number|string|Date)>} data The data to
+   *        be send with a request.
+   * @param {Object.<string, string>} headers Headers object from options provided by the HTTP
+   *        agent.
+   * @returns {string|Object|FormData}
+   * @private
+   */
+  _transformRequestBody(data, headers) {
+    switch (headers['Content-Type']) {
+      case 'application/json':
+        return JSON.stringify(data);
+      case 'application/x-www-form-urlencoded':
+        return this._convertObjectToQueryString(data);
+      case 'multipart/form-data':
+        return this._convertObjectToFormData(data);
+      default:
+        return data;
+    }
+  }
+
+  /**
+   * Returns query string representation of the data parameter.
+   * (Returned string does not contain ? at the beginning)
+   *
+   * @param {Object.<string, (boolean|number|string|Date)>} object The object to be converted
+   * @returns {string} Query string representation of the given object
+   * @private
+   */
+  _convertObjectToQueryString(object) {
+    return Object.keys(object)
+      .map(key => [key, object[key]].map(encodeURIComponent).join('='))
+      .join('&');
+  }
+
+  /**
+   * Converts given data to FormData object.
+   * If FormData object is not supported by the browser the original object is returned.
+   *
+   * @param {Object.<string, (boolean|number|string|Date)>} object The object to be converted
+   * @returns {Object|FormData}
+   * @private
+   */
+  _convertObjectToFormData(object) {
+    if (window.FormData === undefined) {
+      return object;
+    }
+
+    const formDataObject = new FormData();
+    Object.keys(object).forEach(key => formDataObject.append(key, object[key]));
+
+    return formDataObject;
   }
 }

--- a/http/HttpProxy.js
+++ b/http/HttpProxy.js
@@ -520,10 +520,11 @@ export default class HttpProxy {
    * @private
    */
   _convertObjectToFormData(object) {
-    if (window.FormData === undefined) {
+    const window = this._window.getWindow();
+
+    if (!window || !window.FormData) {
       return object;
     }
-
     const formDataObject = new FormData();
     Object.keys(object).forEach(key => formDataObject.append(key, object[key]));
 

--- a/http/__tests__/HttpProxySpec.js
+++ b/http/__tests__/HttpProxySpec.js
@@ -11,7 +11,7 @@ describe('ima.http.HttpProxy', () => {
     ttl: 3600000,
     timeout: 2000,
     repeatRequest: 1,
-    headers: [],
+    headers: {},
     withCredentials: true
   };
   const DATA = {
@@ -198,11 +198,82 @@ describe('ima.http.HttpProxy', () => {
         }
       });
 
+      it(`should convert body to query string if header 'Content-Type' is set to 'application/x-www-form-urlencoded'`, async () => {
+        const options = Object.assign({}, OPTIONS, {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          }
+        });
+        const data = { testKey: 'testValue', testKey2: 'testValue2' };
+        await proxy.request(method, API_URL, data, options);
+
+        if (['get', 'head'].indexOf(method) === -1) {
+          expect(requestInit.body).toBeDefined();
+          expect(typeof requestInit.body).toEqual('string');
+        }
+      });
+
+      it(`should convert body to FormData/Object if header 'Content-Type' is set to 'multipart/form-data'`, async () => {
+        const options = Object.assign({}, OPTIONS, {
+          headers: {
+            'Content-Type': 'multipart/form-data'
+          }
+        });
+        const data = { testKey: 'testValue', testKey2: 'testValue2' };
+        await proxy.request(method, API_URL, data, options);
+
+        if (['get', 'head'].indexOf(method) === -1) {
+          expect(requestInit.body).toBeDefined();
+          expect(typeof requestInit.body).toEqual('object');
+        }
+      });
+
       it('should return null body for HTTP status NO_CONTENT', async () => {
         response.status = StatusCode.NO_CONTENT;
         const result = await proxy.request(method, API_URL, DATA, OPTIONS);
         expect(result.body).toBeNull();
       });
+    });
+  });
+
+  describe('_convertObjectToQueryString', () => {
+    it('should create query string representation of given object', () => {
+      const testObject = { testKey: 'testValue', testKey2: 'testValue2' };
+      const queryString = proxy._convertObjectToQueryString(testObject);
+
+      expect(typeof queryString).toEqual('string');
+      expect(queryString).toEqual('testKey=testValue&testKey2=testValue2');
+    });
+
+    it('should properly escape special characters', () => {
+      const testObject = {
+        testKey: 'test test/test|test?test',
+        testKey2: 'test#test$test^test{test}'
+      };
+      const queryString = proxy._convertObjectToQueryString(testObject);
+      expect(typeof queryString).toEqual('string');
+
+      // testKey
+      expect(queryString.substr(12, 3)).toEqual('%20');
+      expect(queryString.substr(19, 3)).toEqual('%2F');
+      expect(queryString.substr(26, 3)).toEqual('%7C');
+      expect(queryString.substr(33, 3)).toEqual('%3F');
+
+      // testKey2
+      expect(queryString.substr(54, 3)).toEqual('%23');
+      expect(queryString.substr(61, 3)).toEqual('%24');
+      expect(queryString.substr(68, 3)).toEqual('%5E');
+      expect(queryString.substr(75, 3)).toEqual('%7B');
+    });
+  });
+
+  describe('_convertObjectToFormData', () => {
+    it('should return either FormData or Object instance', () => {
+      const testObject = { testKey: 'testValue', testKey2: 'testValue2' };
+      const convertedObject = proxy._convertObjectToFormData(testObject);
+
+      expect(convertedObject).toBeDefined();
+      expect(typeof convertedObject).toEqual('object');
     });
   });
 });

--- a/http/__tests__/HttpProxySpec.js
+++ b/http/__tests__/HttpProxySpec.js
@@ -182,51 +182,49 @@ describe('ima.http.HttpProxy', () => {
       it('should not set any body to a GET/HEAD request', async () => {
         await proxy.request(method, API_URL, DATA, OPTIONS);
 
-        if (['get', 'head'].indexOf(method) >= 0) {
+        if (['get', 'head'].includes(method) === true) {
           expect(requestInit.body).not.toBeDefined();
         } else {
           expect(requestInit.body).toBeDefined();
         }
       });
 
-      it('should set body and Content-Type: application/json for other requests than GET/HEAD even for an empty object', async () => {
-        await proxy.request(method, API_URL, {}, OPTIONS);
+      if (['get', 'head'].includes(method) === false) {
+        it('should set body and Content-Type: application/json for other requests than GET/HEAD even for an empty object', async () => {
+          await proxy.request(method, API_URL, {}, OPTIONS);
 
-        if (['get', 'head'].indexOf(method) === -1) {
           expect(requestInit.body).toBeDefined();
           expect(requestInit.headers['Content-Type']).toBe('application/json');
-        }
-      });
-
-      it(`should convert body to query string if header 'Content-Type' is set to 'application/x-www-form-urlencoded'`, async () => {
-        const options = Object.assign({}, OPTIONS, {
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded'
-          }
         });
-        const data = { testKey: 'testValue', testKey2: 'testValue2' };
-        await proxy.request(method, API_URL, data, options);
 
-        if (['get', 'head'].indexOf(method) === -1) {
+        it(`should convert body to query string if header 'Content-Type' is set to 'application/x-www-form-urlencoded'`, async () => {
+          const options = Object.assign({}, OPTIONS, {
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded'
+            }
+          });
+
+          const data = { testKey: 'testValue', testKey2: 'testValue2' };
+          await proxy.request(method, API_URL, data, options);
+
           expect(requestInit.body).toBeDefined();
           expect(typeof requestInit.body).toEqual('string');
-        }
-      });
-
-      it(`should convert body to FormData/Object if header 'Content-Type' is set to 'multipart/form-data'`, async () => {
-        const options = Object.assign({}, OPTIONS, {
-          headers: {
-            'Content-Type': 'multipart/form-data'
-          }
         });
-        const data = { testKey: 'testValue', testKey2: 'testValue2' };
-        await proxy.request(method, API_URL, data, options);
 
-        if (['get', 'head'].indexOf(method) === -1) {
+        it(`should convert body to FormData/Object if header 'Content-Type' is set to 'multipart/form-data'`, async () => {
+          const options = Object.assign({}, OPTIONS, {
+            headers: {
+              'Content-Type': 'multipart/form-data'
+            }
+          });
+
+          const data = { testKey: 'testValue', testKey2: 'testValue2' };
+          await proxy.request(method, API_URL, data, options);
+
           expect(requestInit.body).toBeDefined();
           expect(typeof requestInit.body).toEqual('object');
-        }
-      });
+        });
+      }
 
       it('should return null body for HTTP status NO_CONTENT', async () => {
         response.status = StatusCode.NO_CONTENT;


### PR DESCRIPTION
Když se jedná o request, který splňuje podmínku `_shouldRequestHaveBody` tak **body** requestu není defaultně formátováno pomocí `JSON.stringify` ale pomocí funkce která odpovídá hlavičce `Content-Type`. Tzn.:
`application/x-www-form-urlencoded` => query string v body
`multipart/form-data` => objekt FormData v body
`application/json` => JSON.stringify