### PR TITLE
#zpravy-333 Microsoft Edge - errory v console

### DIFF
--- a/http/HttpProxy.js
+++ b/http/HttpProxy.js
@@ -296,7 +296,7 @@ export default class HttpProxy {
          * (https://developer.mozilla.org/en-US/docs/Web/API/Headers/getAll)
          */
         headers.forEach((_, headerName) => {
-          plainHeaders[headerName] = headers.get(headerName).join(', ');
+          plainHeaders[headerName] = headers.get(headerName);
         });
       } else {
         /**


### PR DESCRIPTION
Don't use join method in the if branch with Headers.get() method because it returns ByteString ([docs](https://developer.mozilla.org/en-US/docs/Web/API/Headers/get)) with all the header's values (in one string already) unlike Headers.getAll() method (used in the if branch above) which returns all the header's values too but in the Array so there is usage of join method valid and necessary

https://scrumtrack.sbeta.cz/issue/ZPRAVY-333