### PR TITLE
Partial state fix

### DIFF
--- a/extension/AbstractExtension.js
+++ b/extension/AbstractExtension.js
@@ -20,6 +20,15 @@ export default class AbstractExtension extends Extension {
     this._pageStateManager = null;
 
     /**
+     * Flag indicating whether the PageStateManager should be used instead
+     * of partial state.
+     *
+     * @protected
+     * @type {boolean}
+     */
+    this._usingStateManager = false;
+
+    /**
      * The HTTP response code to send to the client.
      *
      * @type {number}
@@ -87,10 +96,10 @@ export default class AbstractExtension extends Extension {
    * @inheritdoc
    */
   getState() {
-    if (this._pageStateManager) {
+    if (this._usingStateManager && this._pageStateManager) {
       return this._pageStateManager.getState();
     } else {
-      return {};
+      return this.getPartialState();
     }
   }
 
@@ -98,7 +107,7 @@ export default class AbstractExtension extends Extension {
    * @inheritdoc
    */
   setPartialState(partialStatePatch) {
-    var newPartialState = Object.assign(
+    const newPartialState = Object.assign(
       {},
       this[this._partialStateSymbol],
       partialStatePatch
@@ -110,14 +119,6 @@ export default class AbstractExtension extends Extension {
    * @inheritdoc
    */
   getPartialState() {
-    if ($Debug && !this[this._partialStateSymbol]) {
-      throw new GenericError(
-        'ima.extension.AbstractExtension: Calling `getPartialState` method ' +
-          'outside of `load` or `update` method. Partial state is ' +
-          'accessible only in `load` and `update` method of the extension ' +
-          'until all the returned promises resolve.'
-      );
-    }
     return this[this._partialStateSymbol] || {};
   }
 
@@ -125,7 +126,7 @@ export default class AbstractExtension extends Extension {
    * @inheritdoc
    */
   clearPartialState() {
-    this[this._partialStateSymbol] = null;
+    this[this._partialStateSymbol] = {};
   }
 
   /**
@@ -147,6 +148,20 @@ export default class AbstractExtension extends Extension {
    */
   setPageStateManager(pageStateManager) {
     this._pageStateManager = pageStateManager;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  switchToStateManager() {
+    this._usingStateManager = true;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  switchToPartialState() {
+    this._usingStateManager = false;
   }
 
   /**

--- a/extension/AbstractExtension.js
+++ b/extension/AbstractExtension.js
@@ -90,7 +90,7 @@ export default class AbstractExtension extends Extension {
     if (this._pageStateManager) {
       return this._pageStateManager.getState();
     } else {
-      return this.getPartialState();
+      return {};
     }
   }
 
@@ -110,6 +110,14 @@ export default class AbstractExtension extends Extension {
    * @inheritdoc
    */
   getPartialState() {
+    if ($Debug && !this[this._partialStateSymbol]) {
+      throw new GenericError(
+        'ima.extension.AbstractExtension: Calling `getPartialState` method ' +
+          'outside of `load` or `update` method. Partial state is ' +
+          'accessible only in `load` and `update` method of the extension ' +
+          'until all the returned promises resolve.'
+      );
+    }
     return this[this._partialStateSymbol] || {};
   }
 
@@ -117,7 +125,7 @@ export default class AbstractExtension extends Extension {
    * @inheritdoc
    */
   clearPartialState() {
-    this[this._partialStateSymbol] = {};
+    this[this._partialStateSymbol] = null;
   }
 
   /**

--- a/extension/Extension.js
+++ b/extension/Extension.js
@@ -167,6 +167,16 @@ export default class Extension {
   setPageStateManager() {}
 
   /**
+   * Enables using PageStateManager for getting state.
+   */
+  switchToStateManager() {}
+
+  /**
+   * Disables using PageStateManager for getting state.
+   */
+  switchToPartialState() {}
+
+  /**
    * Sets the current route parameters. This method is invoked before the
    * {@link Extension#init} method.
    *

--- a/page/manager/AbstractPageManager.js
+++ b/page/manager/AbstractPageManager.js
@@ -352,14 +352,16 @@ export default class AbstractPageManager extends PageManager {
   }
 
   /**
-   * Clears partialState of extensions for managed instance of controller.
+   * Iterates over extensions of current controller and switches each one to
+   * pageStateManager and clears their partial state.
    *
    * @protected
    */
-  _clearPartialState() {
+  _switchToPageStateManager() {
     const controller = this._managedPage.controllerInstance;
 
     for (let extension of controller.getExtensions()) {
+      extension.switchToStateManager();
       extension.clearPartialState();
     }
   }
@@ -382,7 +384,7 @@ export default class AbstractPageManager extends PageManager {
       loadedPageState,
       this._managedPage.options
     );
-    this._clearPartialState();
+    this._switchToPageStateManager();
 
     return response;
   }
@@ -415,6 +417,7 @@ export default class AbstractPageManager extends PageManager {
 
     for (let extension of controller.getExtensions()) {
       extension.setPartialState(extensionsState);
+      extension.switchToPartialState();
       const extensionState = extension.load();
 
       this._setRestrictedPageStateManager(extension, extensionState);
@@ -488,7 +491,7 @@ export default class AbstractPageManager extends PageManager {
       this._managedPage.decoratedController,
       updatedPageState
     );
-    this._clearPartialState();
+    this._switchToPageStateManager();
 
     return response;
   }
@@ -523,6 +526,7 @@ export default class AbstractPageManager extends PageManager {
       const lastRouteParams = extension.getRouteParams();
       extension.setRouteParams(this._managedPage.params);
       extension.setPartialState(extensionsState);
+      extension.switchToPartialState();
       const extensionState = extension.update(lastRouteParams);
 
       this._setRestrictedPageStateManager(extension, extensionState);

--- a/page/manager/__tests__/AbstractPageManagerSpec.js
+++ b/page/manager/__tests__/AbstractPageManagerSpec.js
@@ -333,17 +333,20 @@ describe('ima.page.manager.AbstractPageManager', () => {
         });
     });
 
-    it('should clear partialState', done => {
-      spyOn(pageManager, '_clearPartialState').and.stub();
+    it('should switch extensions to PageStateManager', done => {
+      spyOn(pageManager, '_switchToPageStateManager').and.stub();
 
       pageManager
         ._loadPageSource()
         .then(() => {
-          expect(pageManager._clearPartialState).toHaveBeenCalled();
+          expect(pageManager._switchToPageStateManager).toHaveBeenCalled();
           done();
         })
         .catch(error => {
-          console.error('ima.page.manager:_clearPartialState', error.message);
+          console.error(
+            'ima.page.manager:_switchToPageStateManager',
+            error.message
+          );
           done(error);
         });
     });
@@ -390,13 +393,15 @@ describe('ima.page.manager.AbstractPageManager', () => {
       );
     });
 
-    it('should call extensions setPartialState method', () => {
+    it("should call extension's setPartialState method and switch extension to partial state", () => {
       spyOn(extensionInstance, 'setPartialState').and.stub();
+      spyOn(extensionInstance, 'switchToPartialState').and.stub();
       spyOn(extensionInstance, 'load').and.returnValue(extensionState);
 
       pageManager._getLoadedExtensionsState();
 
       expect(extensionInstance.setPartialState).toHaveBeenCalled();
+      expect(extensionInstance.switchToPartialState).toHaveBeenCalled();
     });
 
     it('should return extensions state together with active controller state', () => {
@@ -486,17 +491,20 @@ describe('ima.page.manager.AbstractPageManager', () => {
         });
     });
 
-    it('should clear partialState', done => {
-      spyOn(pageManager, '_clearPartialState').and.stub();
+    it('should switch extensions to PageStateManager', done => {
+      spyOn(pageManager, '_switchToPageStateManager').and.stub();
 
       pageManager
         ._updatePageSource()
         .then(() => {
-          expect(pageManager._clearPartialState).toHaveBeenCalled();
+          expect(pageManager._switchToPageStateManager).toHaveBeenCalled();
           done();
         })
         .catch(error => {
-          console.error('ima.page.manager:_clearPartialState', error.message);
+          console.error(
+            'ima.page.manager:_switchToPageStateManager',
+            error.message
+          );
           done(error);
         });
     });
@@ -535,13 +543,15 @@ describe('ima.page.manager.AbstractPageManager', () => {
       );
     });
 
-    it('should call extensions setPartialState method', () => {
+    it("should call extension's setPartialState method and switch extension to partial state", () => {
       spyOn(extensionInstance, 'setPartialState').and.stub();
+      spyOn(extensionInstance, 'switchToPartialState').and.stub();
       spyOn(extensionInstance, 'update').and.returnValue(extensionState);
 
       pageManager._getUpdatedExtensionsState();
 
       expect(extensionInstance.setPartialState).toHaveBeenCalled();
+      expect(extensionInstance.switchToPartialState).toHaveBeenCalled();
     });
 
     it('should return extensions state together with active controller state', () => {


### PR DESCRIPTION
- Added `usingStateManager` flag to Extension to explicitly tell when to use PageStateManager instead of temporary partial state.
- Switching each extension to use partial state and settings the extension's partial state before pulling state from `load`/`update` method. Then after a PageRenderer does its job each extension is switched to PageStateManager and its partial state is cleared.