### PR TITLE
Fix for history change bug in IE11 and Edge browsers

### DIFF
--- a/page/handler/PageNavigationHandler.js
+++ b/page/handler/PageNavigationHandler.js
@@ -42,7 +42,12 @@ export default class PageNavigationHandler extends PageManagerHandler {
    * @inheritDoc
    */
   handlePreManagedState(managedPage, nextManagedState, action) {
-    if (managedPage && action && action.type !== ActionTypes.POP_STATE) {
+    if (
+      managedPage &&
+      action &&
+      action.type !== ActionTypes.POP_STATE &&
+      action.type !== ActionTypes.ERROR
+    ) {
       this._saveScrollHistory();
       this._setAddressBar(action.url);
     }

--- a/page/handler/PageNavigationHandler.js
+++ b/page/handler/PageNavigationHandler.js
@@ -1,6 +1,6 @@
 import PageManagerHandler from './PageHandler';
 import Window from '../../window/Window';
-import { ActionTypes } from '../../router/ClientRouter';
+import { ActionTypes } from '../../router/ActionTypes';
 
 /**
  *

--- a/page/handler/__tests__/PageNavigationHandlerSpec.js
+++ b/page/handler/__tests__/PageNavigationHandlerSpec.js
@@ -1,6 +1,6 @@
 import PageNavigationHandler from 'page/handler/PageNavigationHandler';
 import Window from 'window/Window';
-import { ActionTypes } from 'router/ClientRouter';
+import { ActionTypes } from 'router/ActionTypes';
 
 jest.useFakeTimers();
 

--- a/router/AbstractRouter.js
+++ b/router/AbstractRouter.js
@@ -374,7 +374,7 @@ export default class AbstractRouter extends Router {
    *          viewAdapter: ?function(new: React.Component)=
    *        }} options The options overrides route options defined in the
    *        {@code routes.js} configuration file.
-   * @param {{url: string}} [action] An action
+   * @param {{ type: string, event: Event, url: string }} [action] An action
    *        object describing what triggered this routing.
    * @return {Promise<Object<string, *>>} A promise that resolves when the
    *         page is rendered and the result is sent to the client, or

--- a/router/AbstractRouter.js
+++ b/router/AbstractRouter.js
@@ -282,7 +282,9 @@ export default class AbstractRouter extends Router {
       return Promise.reject(error);
     }
 
-    return this._handle(routeError, params, options);
+    return this._handle(routeError, params, options, {
+      url: this.getUrl()
+    });
   }
 
   /**
@@ -303,7 +305,9 @@ export default class AbstractRouter extends Router {
       return Promise.reject(error);
     }
 
-    return this._handle(routeNotFound, params, options);
+    return this._handle(routeNotFound, params, options, {
+      url: this.getUrl()
+    });
   }
 
   /**
@@ -370,7 +374,7 @@ export default class AbstractRouter extends Router {
    *          viewAdapter: ?function(new: React.Component)=
    *        }} options The options overrides route options defined in the
    *        {@code routes.js} configuration file.
-   * @param {{ type: string, event: Event, url: string }} [action] An action
+   * @param {{url: string}} [action] An action
    *        object describing what triggered this routing.
    * @return {Promise<Object<string, *>>} A promise that resolves when the
    *         page is rendered and the result is sent to the client, or

--- a/router/AbstractRouter.js
+++ b/router/AbstractRouter.js
@@ -1,3 +1,4 @@
+import { ActionTypes } from "router/ClientRouter";
 import Events from './Events';
 import Router from './Router';
 import RouteNames from './RouteNames';
@@ -283,7 +284,8 @@ export default class AbstractRouter extends Router {
     }
 
     return this._handle(routeError, params, options, {
-      url: this.getUrl()
+      url: this.getUrl(),
+      type: ActionTypes.ERROR
     });
   }
 
@@ -306,7 +308,8 @@ export default class AbstractRouter extends Router {
     }
 
     return this._handle(routeNotFound, params, options, {
-      url: this.getUrl()
+      url: this.getUrl(),
+      type: ActionTypes.ERROR
     });
   }
 

--- a/router/AbstractRouter.js
+++ b/router/AbstractRouter.js
@@ -1,4 +1,4 @@
-import { ActionTypes } from "router/ClientRouter";
+import { ActionTypes } from './ActionTypes';
 import Events from './Events';
 import Router from './Router';
 import RouteNames from './RouteNames';

--- a/router/ActionTypes.js
+++ b/router/ActionTypes.js
@@ -1,0 +1,31 @@
+/**
+ * Name of actions that can trigger routing
+ *
+ * @enum {string}
+ * @type {Object<string, string>}
+ */
+export const ActionTypes = Object.freeze({
+  /**
+   * @const
+   * @type {string}
+   */
+  REDIRECT: 'redirect',
+
+  /**
+   * @const
+   * @type {string}
+   */
+  CLICK: 'click',
+
+  /**
+   * @const
+   * @type {string}
+   */
+  POP_STATE: 'popstate',
+
+  /**
+   * @const
+   * @type {string}
+   */
+  ERROR: 'error'
+});

--- a/router/ClientRouter.js
+++ b/router/ClientRouter.js
@@ -1,6 +1,7 @@
 // @client-side
 
 import AbstractRouter from './AbstractRouter';
+import { ActionTypes } from './ActionTypes';
 import RouteFactory from './RouteFactory';
 import Dispatcher from '../event/Dispatcher';
 import PageManager from '../page/manager/PageManager';
@@ -29,38 +30,6 @@ const Events = Object.freeze({
    * @type {string}
    */
   POP_STATE: 'popstate'
-});
-
-/**
- * Name of actions that can trigger routing
- *
- * @enum {string}
- * @type {Object<string, string>}
- */
-export const ActionTypes = Object.freeze({
-  /**
-   * @const
-   * @type {string}
-   */
-  REDIRECT: 'redirect',
-
-  /**
-   * @const
-   * @type {string}
-   */
-  CLICK: 'click',
-
-  /**
-   * @const
-   * @type {string}
-   */
-  POP_STATE: 'popstate',
-
-  /**
-   * @const
-   * @type {string}
-   */
-  ERROR: 'error'
 });
 
 /**

--- a/router/ClientRouter.js
+++ b/router/ClientRouter.js
@@ -54,7 +54,13 @@ export const ActionTypes = Object.freeze({
    * @const
    * @type {string}
    */
-  POP_STATE: 'popstate'
+  POP_STATE: 'popstate',
+
+  /**
+   * @const
+   * @type {string}
+   */
+  ERROR: 'error'
 });
 
 /**

--- a/router/__tests__/AbstractRouterSpec.js
+++ b/router/__tests__/AbstractRouterSpec.js
@@ -2,10 +2,10 @@ import GenericError from 'error/GenericError';
 import Dispatcher from 'event/Dispatcher';
 import PageManager from 'page/manager/PageManager';
 import AbstractRouter from 'router/AbstractRouter';
+import { ActionTypes } from 'router/ActionTypes';
 import RouteEvents from 'router/Events';
 import RouteFactory from 'router/RouteFactory';
 import RouteNames from 'router/RouteNames';
-import { ActionTypes } from 'router/ClientRouter';
 
 describe('ima.router.AbstractRouter', () => {
   let router = null;
@@ -28,6 +28,10 @@ describe('ima.router.AbstractRouter', () => {
   };
   let action = {
     type: ActionTypes.REDIRECT
+  };
+  let errorAction = {
+    type: ActionTypes.ERROR,
+    url: 'http://www.domain.com/root/currentRoutePath'
   };
   let currentRoutePath = '/currentRoutePath';
   let Controller = function Controller() {};
@@ -242,7 +246,12 @@ describe('ima.router.AbstractRouter', () => {
       router
         .handleError(params, options)
         .then(response => {
-          expect(router._handle).toHaveBeenCalledWith(route, params, options);
+          expect(router._handle).toHaveBeenCalledWith(
+            route,
+            params,
+            options,
+            errorAction
+          );
           expect(response.error).toEqual(params.error);
           done();
         })
@@ -298,7 +307,12 @@ describe('ima.router.AbstractRouter', () => {
       router
         .handleNotFound(params, options)
         .then(response => {
-          expect(router._handle).toHaveBeenCalledWith(route, params, options);
+          expect(router._handle).toHaveBeenCalledWith(
+            route,
+            params,
+            options,
+            errorAction
+          );
           expect(response.error instanceof GenericError).toEqual(true);
           done();
         })

--- a/router/__tests__/ClientRouterSpec.js
+++ b/router/__tests__/ClientRouterSpec.js
@@ -1,6 +1,7 @@
 import Dispatcher from 'event/Dispatcher';
 import PageManager from 'page/manager/PageManager';
-import ClientRouter, { ActionTypes } from 'router/ClientRouter';
+import { ActionTypes } from 'router/ActionTypes';
+import ClientRouter from 'router/ClientRouter';
 import RouteFactory from 'router/RouteFactory';
 import Window from 'window/Window';
 

--- a/window/ClientWindow.js
+++ b/window/ClientWindow.js
@@ -177,7 +177,7 @@ export default class ClientWindow extends Window {
   /**
    * @inheritdoc
    */
-  pushState(state, title, url) {
+  pushState(state, title, url = null) {
     if (window.history.pushState) {
       window.history.pushState(state, title, url);
     }
@@ -186,7 +186,7 @@ export default class ClientWindow extends Window {
   /**
    * @inheritdoc
    */
-  replaceState(state, title, url) {
+  replaceState(state, title, url = null) {
     if (window.history.replaceState) {
       window.history.replaceState(state, title, url);
     }

--- a/window/Window.js
+++ b/window/Window.js
@@ -194,7 +194,7 @@ export default class Window {
    *        history item, preferably representing the page state.
    * @param {string} title The page title related to the state. Note that
    *        this parameter is ignored by some browsers.
-   * @param {string} url The new URL at which the state is available.
+   * @param {string=} [url=null] The new URL at which the state is available.
    */
   replaceState() {}
 


### PR DESCRIPTION
Fix for a bug in IE 11 and Edge browsers when calling `history.pushState()` and `history.replaceState()` methods with `undefined` url param. [https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10825440/](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10825440/).

Applied similar fix to the one used in https://github.com/ampproject.