### PR TITLE
Fixed OC to create instances of dependencies event if they do not specify `$dependencies` getter.

### DIFF
--- a/ObjectContainer.js
+++ b/ObjectContainer.js
@@ -666,14 +666,12 @@ export default class ObjectContainer {
    *         {@code $dependencies}.
    */
   _getEntryFromClassConstructor(classConstructor) {
-    if (
-      typeof classConstructor === 'function' &&
-      Array.isArray(classConstructor.$dependencies)
-    ) {
-      let entry = this._createEntry(
-        classConstructor,
-        classConstructor.$dependencies
-      );
+    if (typeof classConstructor === 'function') {
+      const classDependencies = Array.isArray(classConstructor.$dependencies)
+        ? classConstructor.$dependencies
+        : [];
+
+      let entry = this._createEntry(classConstructor, classDependencies);
       this._entries.set(classConstructor, entry);
 
       return entry;


### PR DESCRIPTION
Lets say you have `SomeEntityResource` class that specifies its dependencies through `$dependencies` getter or the dependencies are injected in *'app/config/bind.js`.*

```javascript
get $dependencies() {
    return ['$Http', 'API_URL', SomeEntityFactory, Cache];
}
// OR
oc.inject(SomeEntityResource, ['$Http', 'API_URL', SomeEntityFactory, Cache]);
```
If the `SomeEntityFactory` class doesn't have `$dependencies` getter with at least empty array the app will crash on an error saying:
> There is no constant, alias, registered class, registered interface with configured implementation or namespace entry identified as class SomeEntityFactory ....