### PR TITLE
AutoScroll fix

### DIFF
--- a/page/handler/PageNavigationHandler.js
+++ b/page/handler/PageNavigationHandler.js
@@ -41,7 +41,7 @@ export default class PageNavigationHandler extends PageManagerHandler {
   /**
    * @inheritDoc
    */
-  handlePreManagedState(managedPage, nextManagedState, action) {
+  handlePreManagedState(managedPage, nextManagedPage, action) {
     if (
       managedPage &&
       action &&
@@ -57,7 +57,12 @@ export default class PageNavigationHandler extends PageManagerHandler {
    * @inheritDoc
    */
   handlePostManagedState(managedPage, previousManagedPage, action) {
-    const { event } = action;
+	const { event } = action;
+	const { options: { autoScroll } } = managedPage;
+
+	if (!autoScroll) {
+		return;
+	}
 
     if (!event || !event.state || !event.state.scroll) {
       this._scrollTo({ x: 0, y: 0 });

--- a/page/handler/__tests__/PageNavigationHandlerSpec.js
+++ b/page/handler/__tests__/PageNavigationHandlerSpec.js
@@ -69,9 +69,10 @@ describe('ima.page.handler.PageNavigationHandler', () => {
     it('should call window.scrollTo method', () => {
       spyOn(window, 'scrollTo').and.stub();
 
+	  const managedPage = { options: { autoScroll: true } };
       const scroll = { x: 0, y: 340 };
 
-      handler.handlePostManagedState(null, null, {
+      handler.handlePostManagedState(managedPage, null, {
         event: { state: { scroll } }
       });
 
@@ -82,12 +83,27 @@ describe('ima.page.handler.PageNavigationHandler', () => {
     it('should scroll to the top of page for undefined scroll position', () => {
       spyOn(window, 'scrollTo').and.stub();
 
+      const managedPage = { options: { autoScroll: true } };
       const scroll = { x: 0, y: 0 };
 
-      handler.handlePostManagedState(null, null, {});
+      handler.handlePostManagedState(managedPage, null, {});
 
       jest.runAllTimers();
       expect(window.scrollTo).toHaveBeenCalledWith(scroll.x, scroll.y);
     });
+    
+    it('should not call window.scrollTo if current route has autoScroll set to false', () => {
+      spyOn(window, 'scrollTo').and.stub();
+
+      const managedPage = { options: { autoScroll: false } };
+      const scroll = { x: 0, y: 340 };
+
+      handler.handlePostManagedState(managedPage, null, {
+        event: { state: { scroll } }
+      });
+
+      jest.runAllTimers();
+      expect(window.scrollTo).not.toHaveBeenCalled();
+	});
   });
 });


### PR DESCRIPTION
Prevent `handlePostManagedState`'s default behaviour by checking whether route's `autoScroll` option is set to `true` or `false`.