### PR TITLE
fix(main.js): fix hotreload

### DIFF
--- a/main.js
+++ b/main.js
@@ -145,8 +145,7 @@ function hotReloadClientApp(initialAppConfigFunctions) {
   try {
     return pageManager
       .manage(
-        currentRoute.getController(),
-        currentRoute.getView(),
+        currentRoute,
         currentRouteOptions,
         currentRouteInfo.params
       )


### PR DESCRIPTION
Fixed forgotten usage of pageManager.manage method - pass route as a parameter instead of controller and view 