### PR TITLE
Component utils

### DIFF
--- a/Bootstrap.js
+++ b/Bootstrap.js
@@ -73,7 +73,7 @@ export default class Bootstrap {
     let currentApplicationSettings = {};
 
     let plugins = this._config.plugins.concat([
-      { name: 'app', module: this._config }
+      { name: ObjectContainer.APP_BINDING_STATE, module: this._config }
     ]);
 
     plugins

--- a/Bootstrap.js
+++ b/Bootstrap.js
@@ -72,7 +72,9 @@ export default class Bootstrap {
   _initSettings() {
     let currentApplicationSettings = {};
 
-    let plugins = this._config.plugins.concat([this._config]);
+    let plugins = this._config.plugins.concat([
+      { name: 'app', module: this._config }
+    ]);
 
     plugins
       .filter(plugin => typeof plugin.module.initSettings === 'function')

--- a/Bootstrap.js
+++ b/Bootstrap.js
@@ -75,9 +75,9 @@ export default class Bootstrap {
     let plugins = this._config.plugins.concat([this._config]);
 
     plugins
-      .filter(plugin => typeof plugin.initSettings === 'function')
+      .filter(plugin => typeof plugin.module.initSettings === 'function')
       .forEach(plugin => {
-        let allPluginSettings = plugin.initSettings(
+        let allPluginSettings = plugin.module.initSettings(
           ns,
           this._oc,
           this._config.settings
@@ -87,7 +87,7 @@ export default class Bootstrap {
           this._config.settings.$Env
         );
 
-        $Helper.assignRecursively(
+        $Helper.assignRecursivelyWithTracking(plugin.name)(
           currentApplicationSettings,
           environmentPluginSetting
         );
@@ -125,17 +125,30 @@ export default class Bootstrap {
    */
   _bindDependencies() {
     this._oc.setBindingState(ObjectContainer.IMA_BINDING_STATE);
-    this._config.initBindIma(ns, this._oc, this._config.bind);
+    this._config.initBindIma(
+      ns,
+      this._oc,
+      this._config.bind,
+      ObjectContainer.IMA_BINDING_STATE
+    );
 
-    this._oc.setBindingState(ObjectContainer.PLUGIN_BINDING_STATE);
     this._config.plugins
-      .filter(plugin => typeof plugin.initBind === 'function')
+      .filter(plugin => typeof plugin.module.initBind === 'function')
       .forEach(plugin => {
-        plugin.initBind(ns, this._oc, this._config.bind);
+        this._oc.setBindingState(
+          ObjectContainer.PLUGIN_BINDING_STATE,
+          plugin.name
+        );
+        plugin.module.initBind(ns, this._oc, this._config.bind, plugin.name);
       });
 
     this._oc.setBindingState(ObjectContainer.APP_BINDING_STATE);
-    this._config.initBindApp(ns, this._oc, this._config.bind);
+    this._config.initBindApp(
+      ns,
+      this._oc,
+      this._config.bind,
+      ObjectContainer.APP_BINDING_STATE
+    );
   }
 
   /**
@@ -153,9 +166,9 @@ export default class Bootstrap {
     this._config.initServicesIma(ns, this._oc, this._config.services);
 
     this._config.plugins
-      .filter(plugin => typeof plugin.initServices === 'function')
+      .filter(plugin => typeof plugin.module.initServices === 'function')
       .forEach(plugin => {
-        plugin.initServices(ns, this._oc, this._config.services);
+        plugin.module.initServices(ns, this._oc, this._config.services);
       });
 
     this._config.initServicesApp(ns, this._oc, this._config.services);

--- a/ObjectContainer.js
+++ b/ObjectContainer.js
@@ -97,6 +97,16 @@ export default class ObjectContainer {
      * @type {?string}
      */
     this._bindingState = null;
+
+    /**
+     * The current plugin binding to OC.
+     *
+     * The {@linkcode setBindingState()} method may be called for changing
+     * object container binding state only by the bootstrap script.
+     *
+     * @type {?string}
+     */
+    this._bindingPlugin = null;
   }
 
   /**
@@ -418,6 +428,7 @@ export default class ObjectContainer {
   clear() {
     this._entries.clear();
     this._bindingState = null;
+    this._bindingPlugin = null;
 
     return this;
   }
@@ -425,8 +436,9 @@ export default class ObjectContainer {
   /**
    *
    * @param {?string} bindingState
+   * @param {?string} bindingPluginName
    */
-  setBindingState(bindingState) {
+  setBindingState(bindingState, bindingPluginName = null) {
     if (this._bindingState === ObjectContainer.APP_BINDING_STATE) {
       throw new Error(
         `ima.ObjectContainer:setBindingState The setBindingState() ` +
@@ -436,6 +448,10 @@ export default class ObjectContainer {
     }
 
     this._bindingState = bindingState;
+    this._bindingPlugin =
+      bindingState === ObjectContainer.PLUGIN_BINDING_STATE
+        ? bindingPluginName
+        : null;
   }
 
   /**
@@ -521,7 +537,13 @@ export default class ObjectContainer {
       dependencies = classConstructor.$dependencies;
     }
 
-    return new Entry(classConstructor, dependencies, options);
+    let referrer = this._bindingState;
+
+    if (this._bindingState === ObjectContainer.PLUGIN_BINDING_STATE) {
+      referrer = this._bindingPlugin;
+    }
+
+    return new Entry(classConstructor, dependencies, referrer, options);
   }
 
   /**
@@ -699,9 +721,11 @@ class Entry {
    *        class constructor or constant value getter.
    * @param {*[]} [dependencies=[]] The dependencies to pass into the
    *        constructor function.
+   * @param {?string} referrer Reference to part of application that created
+   *        this entry.
    * @param {?{ writeable: boolean }} [options] The Entry options.
    */
-  constructor(classConstructor, dependencies, options) {
+  constructor(classConstructor, dependencies, referrer, options) {
     /**
      * The constructor of the class represented by this entry, or the
      * getter of the value of the constant represented by this entry.
@@ -725,6 +749,14 @@ class Entry {
     this._options = options || {
       writeable: true
     };
+
+    /**
+     * Reference to part of application that created
+     * this entry.
+     *
+     * @type {string}
+     */
+    this._referrer = referrer;
 
     /**
      * Dependencies of the class constructor of the class represented by
@@ -765,6 +797,10 @@ class Entry {
 
   get dependencies() {
     return this._dependencies;
+  }
+
+  get referrer() {
+    return this._referrer;
   }
 
   get writeable() {

--- a/__tests__/BootstrapSpec.js
+++ b/__tests__/BootstrapSpec.js
@@ -19,7 +19,7 @@ describe('Bootstrap', () => {
     settings: {
       $Env: 'prod'
     },
-    plugins: [plugin],
+    plugins: [{ name: 'test-plugin', module: plugin }],
     initSettings: () => environments,
     initBindIma: () => {},
     initBindApp: () => {},
@@ -104,7 +104,8 @@ describe('Bootstrap', () => {
       bootstrap._bindDependencies();
 
       expect(objectContainer.setBindingState).toHaveBeenCalledWith(
-        ObjectContainer.PLUGIN_BINDING_STATE
+        ObjectContainer.PLUGIN_BINDING_STATE,
+        'test-plugin'
       );
     });
 
@@ -127,8 +128,10 @@ describe('Bootstrap', () => {
         namespace,
         objectContainer,
         {
-          $Env: 'prod'
-        }
+          $Env: 'prod',
+          __meta__: {}
+        },
+        'ima'
       );
     });
 
@@ -137,9 +140,15 @@ describe('Bootstrap', () => {
 
       bootstrap._bindDependencies();
 
-      expect(plugin.initBind).toHaveBeenCalledWith(namespace, objectContainer, {
-        $Env: 'prod'
-      });
+      expect(plugin.initBind).toHaveBeenCalledWith(
+        namespace,
+        objectContainer,
+        {
+          $Env: 'prod',
+          __meta__: {}
+        },
+        'test-plugin'
+      );
     });
 
     it('should bind app', () => {
@@ -151,8 +160,10 @@ describe('Bootstrap', () => {
         namespace,
         objectContainer,
         {
-          $Env: 'prod'
-        }
+          $Env: 'prod',
+          __meta__: {}
+        },
+        'app'
       );
     });
   });

--- a/config/bind.js
+++ b/config/bind.js
@@ -30,6 +30,7 @@ import ClientPageManager from '../page/manager/ClientPageManager';
 import PageManager from '../page/manager/PageManager';
 import ServerPageManager from '../page/manager/ServerPageManager';
 import ClientPageRenderer from '../page/renderer/ClientPageRenderer';
+import ComponentUtils from '../page/renderer/ComponentUtils';
 import PageRenderer from '../page/renderer/PageRenderer';
 import PageRendererFactory from '../page/renderer/PageRendererFactory';
 import ServerPageRenderer from '../page/renderer/ServerPageRenderer';
@@ -149,9 +150,14 @@ export default (ns, oc, config) => {
   //Page
   oc.provide(PageStateManager, PageStateManagerImpl);
   oc.bind('$PageStateManager', PageStateManager);
+
   oc.inject(PageFactory, [oc]);
   oc.bind('$PageFactory', PageFactory);
-  oc.inject(PageRendererFactory, [oc, '$React']);
+
+  oc.inject(ComponentUtils, [oc]);
+  oc.bind('$ComponentUtils', ComponentUtils);
+
+  oc.inject(PageRendererFactory, [ComponentUtils, '$React']);
   oc.bind('$PageRendererFactory', PageRendererFactory);
 
   if (oc.get(Window).isClient()) {

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@commitlint/cli": "^7.5.0",
-    "@commitlint/config-conventional": "^7.5.0",
     "@babel/core": "^7.2.2",
+    "@commitlint/cli": "^8.1.0",
+    "@commitlint/config-conventional": "^7.5.0",
     "@fortawesome/fontawesome-free": "^5.7.1",
     "autocannon": "^3.2.0",
     "babel-core": "^6.26.0",
@@ -87,11 +87,11 @@
     "react": "16.8.3",
     "react-dom": "16.8.3",
     "to-mock": "^1.4.1",
-    "verdaccio": "^3.11.0"
+    "verdaccio": "^4.2.2"
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "ima-helpers": "^0.16.0",
+    "ima-helpers": "^0.16.1",
     "node-fetch": "^2.1.2"
   },
   "peerDependencies": {

--- a/page/renderer/ComponentUtils.js
+++ b/page/renderer/ComponentUtils.js
@@ -50,16 +50,16 @@ export default class ComponentUtils {
    * @returns {Object<string, Object>}
    */
   getUtils() {
-    if (this._oc.has('$Utils')) {
-      // fallback for backward compatibility
-      return this._oc.get('$Utils');
-    }
-
     const utilities = {};
 
     // create instance of each utility class
     for (const utilityAlias of Object.keys(this._utilities)) {
       utilities[utilityAlias] = this._oc.get(this._utilities[utilityAlias]);
+    }
+
+    if (this._oc.has('$Utils')) {
+      // fallback for backward compatibility
+      Object.assign(utilities, this._oc.get('$Utils'));
     }
 
     return utilities;

--- a/page/renderer/ComponentUtils.js
+++ b/page/renderer/ComponentUtils.js
@@ -1,63 +1,67 @@
-
 export default class ComponentUtils {
-
+  /**
+   * Initializes the registry used for managing component utils.
+   *
+   * @param {ObjectContainer} oc The application's dependency injector - the
+   *        object container.
+   */
+  constructor(oc) {
     /**
-     * Initializes the registry used for managing component utils.
+     * The application's dependency injector - the object container.
      *
-     * @param {ObjectContainer} oc The application's dependency injector - the
-     *        object container.
+     * @type {ObjectContainer}
      */
-    constructor(oc) {
-        /**
-         * The application's dependency injector - the object container.
-         *
-         * @type {ObjectContainer}
-         */
-        this._oc = oc;
-
-        /**
-         * Map of registered utilities.
-         * 
-         * @type {Object<string, Object>}
-         */
-        this._utilities = {};
-    }
+    this._oc = oc;
 
     /**
-     * Registers single utility class or multiple classes in alias->class mapping.
-     * 
-     * @param {function(new: Object)|Object<string, function(new: Object)>} componentUtilityClass
-     * @param {string|null} alias
-     * @returns {Object|Object<string, Object>}
+     * Map of registered utilities.
+     *
+     * @type {Object<string, Object>}
      */
-    register(componentUtilityClass, alias = null) {
-        if (typeof componentUtilityClass === 'function') {
+    this._utilities = {};
+  }
 
-            const utilityInstance = this._oc.get(componentUtilityClass);
-            this._utilities[alias || componentUtilityClass.name] = utilityInstance;
-
-            return utilityInstance;
-
-        } else if (typeof componentUtilityClass === 'object') {
-            const utilityInstances = {};
-
-            for (const alias of Object.keys(componentUtilityClass)) {
-                const instance = this._oc.get(componentUtilityClass);
-
-                this._utilities[alias] = instance;
-                utilityInstances[alias] = instance;
-            }
-
-            return utilityInstances;
+  /**
+   * Registers single utility class or multiple classes in alias->class mapping.
+   *
+   * @param {function(new: Object)|Object<string, function(new: Object)>} componentUtilityClass
+   * @param {string|null} alias
+   * @returns {Object|Object<string, Object>}
+   */
+  register(componentUtilityClass, alias = null) {
+    if (typeof componentUtilityClass === 'function') {
+      this._utilities[
+        alias || componentUtilityClass.name
+      ] = componentUtilityClass;
+    } else if (typeof componentUtilityClass === 'object') {
+      for (const alias of Object.keys(componentUtilityClass)) {
+        if (!componentUtilityClass.hasOwnProperty(alias)) {
+          continue;
         }
+
+        this._utilities[alias] = componentUtilityClass[alias];
+      }
+    }
+  }
+
+  /**
+   * Returns object containing all registered utilities
+   *
+   * @returns {Object<string, Object>}
+   */
+  getUtils() {
+    if (this._oc.has('$Utils')) {
+      // fallback for backward compatibility
+      return this._oc.get('$Utils');
     }
 
-    /**
-     * Returns object containing all registered utilities
-     * 
-     * @returns {Object<string, Object>}
-     */
-    getUtils() {
-        return this._utilities;
+    const utilities = {};
+
+    // create instance of each utility class
+    for (const utilityAlias of Object.keys(this._utilities)) {
+      utilities[utilityAlias] = this._oc.get(this._utilities[utilityAlias]);
     }
+
+    return utilities;
+  }
 }

--- a/page/renderer/ComponentUtils.js
+++ b/page/renderer/ComponentUtils.js
@@ -42,7 +42,11 @@ export default class ComponentUtils {
       if (this._utilities) {
         this._createUtilityInstance(alias, componentUtilityClass);
       }
-    } else if (typeof name === 'object') {
+    } else if (
+      name &&
+      typeof name === 'object' &&
+      name.constructor === Object
+    ) {
       const utilityClasses = name;
 
       for (const alias of Object.keys(utilityClasses)) {

--- a/page/renderer/ComponentUtils.js
+++ b/page/renderer/ComponentUtils.js
@@ -54,11 +54,7 @@ export default class ComponentUtils {
           continue;
         }
 
-        this._utilityClasses[alias] = utilityClasses[alias];
-
-        if (this._utilities) {
-          this._createUtilityInstance(alias, utilityClasses[alias]);
-        }
+        this.register(alias, utilityClasses[alias]);
       }
     }
   }

--- a/page/renderer/ComponentUtils.js
+++ b/page/renderer/ComponentUtils.js
@@ -1,0 +1,63 @@
+
+export default class ComponentUtils {
+
+    /**
+     * Initializes the registry used for managing component utils.
+     *
+     * @param {ObjectContainer} oc The application's dependency injector - the
+     *        object container.
+     */
+    constructor(oc) {
+        /**
+         * The application's dependency injector - the object container.
+         *
+         * @type {ObjectContainer}
+         */
+        this._oc = oc;
+
+        /**
+         * Map of registered utilities.
+         * 
+         * @type {Object<string, Object>}
+         */
+        this._utilities = {};
+    }
+
+    /**
+     * Registers single utility class or multiple classes in alias->class mapping.
+     * 
+     * @param {function(new: Object)|Object<string, function(new: Object)>} componentUtilityClass
+     * @param {string|null} alias
+     * @returns {Object|Object<string, Object>}
+     */
+    register(componentUtilityClass, alias = null) {
+        if (typeof componentUtilityClass === 'function') {
+
+            const utilityInstance = this._oc.get(componentUtilityClass);
+            this._utilities[alias || componentUtilityClass.name] = utilityInstance;
+
+            return utilityInstance;
+
+        } else if (typeof componentUtilityClass === 'object') {
+            const utilityInstances = {};
+
+            for (const alias of Object.keys(componentUtilityClass)) {
+                const instance = this._oc.get(componentUtilityClass);
+
+                this._utilities[alias] = instance;
+                utilityInstances[alias] = instance;
+            }
+
+            return utilityInstances;
+        }
+    }
+
+    /**
+     * Returns object containing all registered utilities
+     * 
+     * @returns {Object<string, Object>}
+     */
+    getUtils() {
+        return this._utilities;
+    }
+}

--- a/page/renderer/ComponentUtils.js
+++ b/page/renderer/ComponentUtils.js
@@ -26,6 +26,13 @@ export default class ComponentUtils {
      * @type {Object<string, Object>}
      */
     this._utilities = null;
+
+    /**
+     * Map of referrers to utilities
+     *
+     * @type {Object<string, string>}
+     */
+    this._utilityReferrers = {};
   }
 
   /**
@@ -33,11 +40,16 @@ export default class ComponentUtils {
    *
    * @param {string|Object<string, function(new: T, ...*)|function(...*): T>} name
    * @param {function(new: T, ...*)|function(...*): T} componentUtilityClass
+   * @param {?string} referrer
    */
-  register(name, componentUtilityClass) {
+  register(name, componentUtilityClass, referrer = null) {
     if (typeof componentUtilityClass === 'function') {
       const alias = String(name);
       this._utilityClasses[alias] = componentUtilityClass;
+
+      if (referrer && typeof referrer === 'string') {
+        this._utilityReferrers[alias] = referrer;
+      }
 
       if (this._utilities) {
         this._createUtilityInstance(alias, componentUtilityClass);
@@ -48,13 +60,14 @@ export default class ComponentUtils {
       name.constructor === Object
     ) {
       const utilityClasses = name;
+      referrer = componentUtilityClass;
 
       for (const alias of Object.keys(utilityClasses)) {
         if (!utilityClasses.hasOwnProperty(alias)) {
           continue;
         }
 
-        this.register(alias, utilityClasses[alias]);
+        this.register(alias, utilityClasses[alias], referrer);
       }
     }
   }
@@ -82,6 +95,13 @@ export default class ComponentUtils {
     }
 
     return this._utilities;
+  }
+
+  /**
+   * @returns {Object<string, string>}
+   */
+  getReferrers() {
+    return this._utilityReferrers;
   }
 
   /**

--- a/page/renderer/PageRendererFactory.js
+++ b/page/renderer/PageRendererFactory.js
@@ -7,18 +7,17 @@ export default class PageRendererFactory {
   /**
    * Initializes the factory used by the page renderer.
    *
-   * @param {ObjectContainer} oc The application's dependency injector - the
-   *        object container.
+   * @param {ComponentUtils} componentUtils The registry of component utilities.
    * @param {React} React The React framework instance to use to render the
    *        page.
    */
-  constructor(oc, React) {
+  constructor(componentUtils, React) {
     /**
-     * The application's dependency injector - the object container.
+     * The registry of component utilities.
      *
-     * @type {ObjectContainer}
+     * @type {ComponentUtils}
      */
-    this._oc = oc;
+    this._componentUtils = componentUtils;
 
     /**
      * Rect framework instance, used to render the page.
@@ -33,7 +32,7 @@ export default class PageRendererFactory {
    * Return object of services which are defined for alias $Utils.
    */
   getUtils() {
-    return this._oc.get('$Utils');
+    return this._componentUtils.getUtils();
   }
 
   /**

--- a/page/renderer/__tests__/ComponentUtilsSpec.js
+++ b/page/renderer/__tests__/ComponentUtilsSpec.js
@@ -17,20 +17,13 @@ describe('ComponentUtils', () => {
   });
 
   describe('register() method', () => {
-    it('should register utility class under its own real name.', () => {
-      componentUtils.register(SomeMockHelper);
+    it('should register utility class', () => {
+      componentUtils.register('SomeHelper', SomeMockHelper);
 
-      expect(componentUtils._utilities['SomeMockHelper']).not.toBeUndefined();
-      expect(componentUtils._utilities['SomeMockHelper']).toEqual(
+      expect(componentUtils._utilityClasses['SomeHelper']).not.toBeUndefined();
+      expect(componentUtils._utilityClasses['SomeHelper']).toEqual(
         SomeMockHelper
       );
-    });
-
-    it('should register utility class under given alias.', () => {
-      componentUtils.register(SomeMockHelper, 'MockHelper');
-
-      expect(componentUtils._utilities['MockHelper']).not.toBeUndefined();
-      expect(componentUtils._utilities['MockHelper']).toEqual(SomeMockHelper);
     });
 
     it('should register multiple classes given in form of an Object.', () => {
@@ -39,8 +32,10 @@ describe('ComponentUtils', () => {
         SomeHelper
       });
 
-      expect(componentUtils._utilities['MockHelper']).toEqual(SomeMockHelper);
-      expect(componentUtils._utilities['SomeHelper']).toEqual(SomeHelper);
+      expect(componentUtils._utilityClasses['MockHelper']).toEqual(
+        SomeMockHelper
+      );
+      expect(componentUtils._utilityClasses['SomeHelper']).toEqual(SomeHelper);
     });
   });
 
@@ -70,6 +65,14 @@ describe('ComponentUtils', () => {
       expect(oc.get).toHaveBeenCalledTimes(2);
       expect(utils['SomeHelper'] instanceof SomeHelper).toBeTruthy();
       expect(utils['SomeMockHelper'] instanceof SomeMockHelper).toBeTruthy();
+    });
+
+    it('should not create instances again.', () => {
+      const utils = (componentUtils._utilities = {});
+      spyOn(componentUtils, '_createUtilityInstance').and.stub();
+
+      expect(componentUtils.getUtils()).toBe(utils);
+      expect(componentUtils._createUtilityInstance).not.toHaveBeenCalled();
     });
   });
 });

--- a/page/renderer/__tests__/ComponentUtilsSpec.js
+++ b/page/renderer/__tests__/ComponentUtilsSpec.js
@@ -1,0 +1,75 @@
+import { toMockedInstance } from 'to-mock';
+
+import ObjectContainer from 'ObjectContainer';
+import ComponentUtils from 'page/renderer/ComponentUtils';
+
+class SomeMockHelper {}
+
+class SomeHelper {}
+
+describe('ComponentUtils', () => {
+  let componentUtils = null;
+
+  const oc = toMockedInstance(ObjectContainer);
+
+  beforeEach(() => {
+    componentUtils = new ComponentUtils(oc);
+  });
+
+  describe('register() method', () => {
+    it('should register utility class under its own real name.', () => {
+      componentUtils.register(SomeMockHelper);
+
+      expect(componentUtils._utilities['SomeMockHelper']).not.toBeUndefined();
+      expect(componentUtils._utilities['SomeMockHelper']).toEqual(
+        SomeMockHelper
+      );
+    });
+
+    it('should register utility class under given alias.', () => {
+      componentUtils.register(SomeMockHelper, 'MockHelper');
+
+      expect(componentUtils._utilities['MockHelper']).not.toBeUndefined();
+      expect(componentUtils._utilities['MockHelper']).toEqual(SomeMockHelper);
+    });
+
+    it('should register multiple classes given in form of an Object.', () => {
+      componentUtils.register({
+        MockHelper: SomeMockHelper,
+        SomeHelper
+      });
+
+      expect(componentUtils._utilities['MockHelper']).toEqual(SomeMockHelper);
+      expect(componentUtils._utilities['SomeHelper']).toEqual(SomeHelper);
+    });
+  });
+
+  describe('getUtils() method.', () => {
+    beforeEach(() => {
+      spyOn(oc, 'get').and.callFake(entity =>
+        typeof entity === 'function' ? new entity() : entity
+      );
+
+      componentUtils.register({
+        SomeMockHelper,
+        SomeHelper
+      });
+    });
+
+    it('should return $Utils constant from OC if created.', () => {
+      spyOn(oc, 'has').and.callFake(entity => entity === '$Utils');
+
+      componentUtils.getUtils();
+
+      expect(oc.get).toHaveBeenCalledWith('$Utils');
+    });
+
+    it('should create instace of each registered class through OC.', () => {
+      const utils = componentUtils.getUtils();
+
+      expect(oc.get).toHaveBeenCalledTimes(2);
+      expect(utils['SomeHelper'] instanceof SomeHelper).toBeTruthy();
+      expect(utils['SomeMockHelper'] instanceof SomeMockHelper).toBeTruthy();
+    });
+  });
+});

--- a/vendorLinker.js
+++ b/vendorLinker.js
@@ -36,7 +36,7 @@ export class VendorLinker {
     this._modules.set(moduleName, moduleValues);
 
     if (typeof moduleValues.$registerImaPlugin === 'function') {
-      this._plugins.push(moduleValues);
+      this._plugins.push({ name: moduleName, module: moduleValues });
     }
 
     $IMA.Loader.register(moduleName, [], exports => ({


### PR DESCRIPTION
ComponentUtils class provides a way of registering component helpers (accessible via `this.utils`).
Current solution (registration in **bind.js** to `$Utils` constant) is inefficient and does not allow to register utilities from plugins or override them.

Every utility should be registered through `register()` method. It's instance is created only when `getUtils()` is called (before a page is rendered).

This change is not breaking any current functionality. You can still use `$Utils` constant. Its contents will extend (override) registered utilities.