### PR TITLE
React new Context API codemod

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "gulp-rename": "^1.3.0",
     "husky": "^3.0.5",
     "jest": "^24.9.0",
+    "jscodeshift": "^0.6.4",
     "jsdoc-to-markdown": "^5.0.1",
     "jsdom": "^15.1.1",
     "lint-staged": "^9.2.5",

--- a/utils/transform/__tests__/context-api-v17Spec.js
+++ b/utils/transform/__tests__/context-api-v17Spec.js
@@ -1,0 +1,96 @@
+import { defineInlineTest } from 'jscodeshift/src/testUtils';
+import { getOptions } from '../transformUtils/testUtils';
+import transform from '../context-api-v17';
+
+describe('ima.utils.transform.context-api-v17', () => {
+  defineInlineTest(
+    transform,
+    getOptions(),
+    `
+export default class MyComponent extends AbstractComponent {
+	render() {}
+}
+`,
+    `
+export default class MyComponent extends AbstractComponent {
+	render() {}
+}
+`,
+    "Should not touch the code if it doesn't define context"
+  );
+
+  defineInlineTest(
+    transform,
+    getOptions(),
+    `
+import Core from '@ima/core';
+
+export default class MyComponent extends AbstractComponent {
+	static get contextTypes() {
+		return {
+			$Utils: PropTypes.object,
+			urlParams: PropTypes.object
+		};
+	}
+}
+`,
+    `
+import Core, { PageContext } from '@ima/core';
+
+export default class MyComponent extends AbstractComponent {
+	static get contextType() {
+		return PageContext;
+	}
+}
+`,
+    'Should add named import to existing @ima/core import statement'
+  );
+
+  defineInlineTest(
+    transform,
+    getOptions(),
+    `
+export default class MyComponent extends AbstractComponent {
+	static get contextTypes() {
+		return {
+			$Utils: PropTypes.object,
+			urlParams: PropTypes.object
+		};
+	}
+}
+`,
+    `
+import { PageContext } from '@ima/core';
+export default class MyComponent extends AbstractComponent {
+	static get contextType() {
+		return PageContext;
+	}
+}
+`,
+    "Should add named import to top of the page if it doesn't exists"
+  );
+
+  defineInlineTest(
+    transform,
+    getOptions(),
+    `
+export default class MyComponent extends AbstractComponent {
+	static get contextTypes() {
+		return {
+			$Utils: PropTypes.object,
+			urlParams: PropTypes.object
+		};
+	}
+}
+`,
+    `
+import { PageContext } from '@ima/core';
+export default class MyComponent extends AbstractComponent {
+	static get contextType() {
+		return PageContext;
+	}
+}
+`,
+    'Should replace contextTypes with contextType returning PageContext'
+  );
+});

--- a/utils/transform/__tests__/context-api-v17Spec.js
+++ b/utils/transform/__tests__/context-api-v17Spec.js
@@ -1,6 +1,6 @@
-import { defineInlineTest } from 'jscodeshift/src/testUtils';
-import { getOptions } from '../transformUtils/testUtils';
-import transform from '../context-api-v17';
+const { defineInlineTest } = require('jscodeshift/src/testUtils');
+const { getOptions } = require('../transformUtils/testUtils');
+const transform = require('../context-api-v17');
 
 describe('ima.utils.transform.context-api-v17', () => {
   defineInlineTest(

--- a/utils/transform/__tests__/import-v17Spec.js
+++ b/utils/transform/__tests__/import-v17Spec.js
@@ -1,0 +1,48 @@
+import { defineInlineTest } from 'jscodeshift/src/testUtils';
+import { getOptions } from '../transformUtils/testUtils';
+import transform from '../import-v17';
+
+describe('ima.utils.transform.import-v17', () => {
+  defineInlineTest(
+    transform,
+    getOptions(),
+    `
+import Foo from 'bar';
+
+export default class MyComponent extends AbstractComponent {
+	render() {}
+}
+`,
+    `
+import Foo from 'bar';
+
+export default class MyComponent extends AbstractComponent {
+	render() {}
+}
+`,
+    "Should not touch the code if it doesn't import ima."
+  );
+
+  defineInlineTest(
+    transform,
+    getOptions(),
+    `
+import Foo from 'bar';
+import AbstractComponent from 'ima/page/AbstractComponent';
+import { defaultCssClasses } from 'ima/page/componentHelpers';
+
+export default class MyComponent extends AbstractComponent {
+	render() {}
+}
+`,
+    `
+import { AbstractComponent, defaultCssClasses } from '@ima/core';
+import Foo from 'bar';
+
+export default class MyComponent extends AbstractComponent {
+	render() {}
+}
+`,
+    'Should rename all ima imports to new namespaced version.'
+  );
+});

--- a/utils/transform/__tests__/import-v17Spec.js
+++ b/utils/transform/__tests__/import-v17Spec.js
@@ -1,6 +1,6 @@
-import { defineInlineTest } from 'jscodeshift/src/testUtils';
-import { getOptions } from '../transformUtils/testUtils';
-import transform from '../import-v17';
+const { defineInlineTest } = require('jscodeshift/src/testUtils');
+const { getOptions } = require('../transformUtils/testUtils');
+const transform = require('../import-v17');
 
 describe('ima.utils.transform.import-v17', () => {
   defineInlineTest(

--- a/utils/transform/context-api-v17.js
+++ b/utils/transform/context-api-v17.js
@@ -1,0 +1,30 @@
+import { addNamedImports } from './transformUtils/imports';
+import { getOptions } from './transformUtils/testUtils';
+
+module.exports = function(fileInfo, api, options) {
+  const { jscodeshift: j } = api;
+  const ast = j(fileInfo.source);
+
+  const contextTypes = ast.find(j.MethodDefinition, {
+    key: {
+      name: 'contextTypes'
+    }
+  });
+
+  if (contextTypes.size()) {
+    // Replace contextTypes method with contextType
+    const identifier = contextTypes.get('key', 0);
+    identifier.node.name = 'contextType';
+
+    // Replace body of the method with return statement which returns PageContext
+    contextTypes
+      .find(j.ReturnStatement)
+      .find(j.ObjectExpression)
+      .replaceWith(j.identifier('PageContext'));
+
+    // Add Page context named import to a file
+    addNamedImports(j, ast, ['PageContext'], '@ima/core');
+  }
+
+  return ast.toSource(Object.assign({}, getOptions(), options));
+};

--- a/utils/transform/context-api-v17.js
+++ b/utils/transform/context-api-v17.js
@@ -1,5 +1,5 @@
-import { addNamedImports } from './transformUtils/imports';
-import { getOptions } from './transformUtils/testUtils';
+const { addNamedImports } = require('./transformUtils/imports');
+const { getOptions } = require('./transformUtils/testUtils');
 
 module.exports = function(fileInfo, api, options) {
   const { jscodeshift: j } = api;

--- a/utils/transform/import-v17.js
+++ b/utils/transform/import-v17.js
@@ -1,4 +1,4 @@
-import { getOptions } from './transformUtils/testUtils';
+const { getOptions } = require('./transformUtils/testUtils');
 
 module.exports = function(fileInfo, api, options) {
   const jscodeshift = api.jscodeshift;

--- a/utils/transform/import-v17.js
+++ b/utils/transform/import-v17.js
@@ -1,9 +1,11 @@
-module.exports = function(fileInfo, api) {
+import { getOptions } from './transformUtils/testUtils';
+
+module.exports = function(fileInfo, api, options) {
   const jscodeshift = api.jscodeshift;
-  const root = jscodeshift(fileInfo.source);
+  const ast = jscodeshift(fileInfo.source);
   const regexIma = /ima\//;
 
-  const importDeclarations = root
+  const importDeclarations = ast
     .find(jscodeshift.ImportDeclaration)
     .filter(node => {
       return regexIma.test(node.value.source.value);
@@ -34,8 +36,8 @@ module.exports = function(fileInfo, api) {
 
     importDeclarations.remove();
 
-    root.get().node.program.body.unshift(newImport);
+    ast.get().node.program.body.unshift(newImport);
   }
 
-  return root.toSource({ quote: 'single' });
+  return ast.toSource(Object.assign({}, getOptions(), options));
 };

--- a/utils/transform/transformUtils/__tests__/importsSpec.js
+++ b/utils/transform/transformUtils/__tests__/importsSpec.js
@@ -1,0 +1,75 @@
+import j from 'jscodeshift';
+import { source } from '../testUtils';
+import { addNamedImports, findImport } from '../imports';
+
+describe('ima.utils.transform.transformUtils.imports', () => {
+  let ast = null;
+  const testCase = `
+import Atoms from '@usa/plugin-atoms';
+import { ReportService } from '@usa/plugin-report';
+import Utils, { RegressionHelper, LinkHelper, ImageHelper } from '@usa/utils';
+import * as lod from 'lodash';
+
+const date = new Date();
+		`;
+
+  beforeEach(() => {
+    ast = j(testCase);
+  });
+
+  describe('addNamedImports', () => {
+    it('should add specified list of named imports at top of the file', () => {
+      addNamedImports(
+        j,
+        ast,
+        ['NamedImport1', 'NamedImport2'],
+        'named-import-plugin'
+      );
+
+      expect(source(ast)).toBe(`
+import { NamedImport1, NamedImport2 } from 'named-import-plugin';
+import Atoms from '@usa/plugin-atoms';
+import { ReportService } from '@usa/plugin-report';
+import Utils, { RegressionHelper, LinkHelper, ImageHelper } from '@usa/utils';
+import * as lod from 'lodash';
+
+const date = new Date();
+		`);
+    });
+
+    it('should add specified list of named imports to existing ones', () => {
+      addNamedImports(j, ast, ['Link', 'H1', 'H2'], '@usa/plugin-atoms');
+      addNamedImports(j, ast, ['ComponentUtils'], '@usa/utils');
+
+      expect(source(ast)).toBe(`
+import Atoms, { Link, H1, H2 } from '@usa/plugin-atoms';
+import { ReportService } from '@usa/plugin-report';
+import Utils, { ComponentUtils, RegressionHelper, LinkHelper, ImageHelper } from '@usa/utils';
+import * as lod from 'lodash';
+
+const date = new Date();
+		`);
+    });
+
+    it('should not do anything if all imports are already defined', () => {
+      addNamedImports(j, ast, ['RegressionHelper', 'LinkHelper'], '@usa/utils');
+
+      expect(source(ast)).toBe(testCase);
+    });
+  });
+
+  describe('findImport', () => {
+    it('should return empty node if import was not found', () => {
+      const result = findImport(j, ast, '@usa/my-custom-package');
+
+      expect(result.size()).toBe(0);
+    });
+
+    it('should return ImportDeclaration collection if import was found', () => {
+      const result = findImport(j, ast, '@usa/utils');
+
+      expect(result.isOfType(j.ImportDeclaration)).toBe(true);
+      expect(result.size()).toBe(1);
+    });
+  });
+});

--- a/utils/transform/transformUtils/__tests__/importsSpec.js
+++ b/utils/transform/transformUtils/__tests__/importsSpec.js
@@ -1,6 +1,6 @@
-import j from 'jscodeshift';
-import { source } from '../testUtils';
-import { addNamedImports, findImport } from '../imports';
+const j = require('jscodeshift');
+const { source } = require('../testUtils');
+const { addNamedImports, findImport } = require('../imports');
 
 describe('ima.utils.transform.transformUtils.imports', () => {
   let ast = null;

--- a/utils/transform/transformUtils/imports.js
+++ b/utils/transform/transformUtils/imports.js
@@ -6,7 +6,7 @@
  * @param {string} pkg Package name.
  * @returns {Collection}
  */
-export function findImport(j, ast, pkg) {
+function findImport(j, ast, pkg) {
   return ast.find(j.ImportDeclaration, {
     source: {
       value: pkg
@@ -28,7 +28,7 @@ export function findImport(j, ast, pkg) {
  * @param {[string]} names Named import names.
  * @param {string} pkg Package name.
  */
-export function addNamedImports(j, ast, names, pkg) {
+function addNamedImports(j, ast, names, pkg) {
   // Add to existing import declaration if it exists
   const existingImport = findImport(j, ast, pkg);
   if (existingImport.size()) {
@@ -62,3 +62,8 @@ export function addNamedImports(j, ast, names, pkg) {
       );
   }
 }
+
+module.exports = {
+  findImport,
+  addNamedImports
+};

--- a/utils/transform/transformUtils/imports.js
+++ b/utils/transform/transformUtils/imports.js
@@ -1,0 +1,64 @@
+/**
+ * Find import statements with specified package name.
+ *
+ * @param {core.JSCodeshift|core} j Reference to the jscodeshift library.
+ * @param {Collection} ast Root collection of AST.
+ * @param {string} pkg Package name.
+ * @returns {Collection}
+ */
+export function findImport(j, ast, pkg) {
+  return ast.find(j.ImportDeclaration, {
+    source: {
+      value: pkg
+    }
+  });
+}
+
+/**
+ * Add named imports to JS import statement with specified package name.
+ * If some import from specified package already exists, named imports are
+ * added to this import statement. Otherwise new import statement is created
+ * and added to top of the transformed file.
+ *
+ * @example
+ * addNamedImports(j, ast, ['LinkHelper'], '@cns/utils');
+ *
+ * @param {core.JSCodeshift|core} j Reference to the jscodeshift library.
+ * @param {Collection} ast Root collection of AST.
+ * @param {[string]} names Named import names.
+ * @param {string} pkg Package name.
+ */
+export function addNamedImports(j, ast, names, pkg) {
+  // Add to existing import declaration if it exists
+  const existingImport = findImport(j, ast, pkg);
+  if (existingImport.size()) {
+    const specifiersRoot = existingImport.get('specifiers', 0);
+
+    names.map(name => {
+      // Check for duplicates
+      const isDupe = existingImport
+        .find(j.ImportSpecifier, {
+          imported: {
+            name
+          }
+        })
+        .size();
+
+      if (!isDupe) {
+        specifiersRoot.insertBefore(j.importSpecifier(j.identifier(name)));
+      }
+    });
+  } else {
+    ast
+      .find(j.Program)
+      .get('body', 0)
+      .insertBefore(
+        j.importDeclaration(
+          names.map(name => {
+            return j.importSpecifier(j.identifier(name));
+          }),
+          j.literal(pkg)
+        )
+      );
+  }
+}

--- a/utils/transform/transformUtils/testUtils.js
+++ b/utils/transform/transformUtils/testUtils.js
@@ -1,0 +1,27 @@
+/**
+ * Returns modified default options object that is passed to recast
+ * in jscodeshift toSource function.
+ *
+ * @returns {Object} JSCodeshift output recast options.
+ */
+export function getOptions() {
+  return {
+    quote: 'single',
+    trailingComma: {
+      objects: false,
+      arrays: false,
+      functions: false
+    }
+  };
+}
+
+/**
+ * Returns transformed ast tree with default testing options.
+ * It is essentially wrapper for ast.toSource with default options.
+ *
+ * @param {Collection} ast root AST collection.
+ * @returns {string|*} transformed AST source code.
+ */
+export function source(ast) {
+  return ast.toSource(getOptions());
+}

--- a/utils/transform/transformUtils/testUtils.js
+++ b/utils/transform/transformUtils/testUtils.js
@@ -25,3 +25,8 @@ export function getOptions() {
 export function source(ast) {
   return ast.toSource(getOptions());
 }
+
+module.exports = {
+  getOptions,
+  source
+};


### PR DESCRIPTION
This PR adds jscodeshift codemod to automate transition to the new React API in IMA v17 along with some other transformation related stuff. Specifically:
- Added context-api-v17 jscodeshift codemod.
- Added tests for both context-api-v17 and import-v17 codemods.
- Added few transformation utility functions along with their tests.
- As a result of all above, added jscodeshift as dev dependency`.